### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.3",
   "unity": "6000.0",
   "dependencies": {
-    "com.unity.test-framework": "1.5.1",
+    "com.unity.test-framework": "1.4.6",
     "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.nuget.mono-cecil": "1.11.4"
   },


### PR DESCRIPTION
Adding the package using Package Manager gives an error that com.unity.test-framework doesn't exist (even when cloning the repository manually)

This fix uses Test Framework 1.4.6 (The latest available version) as 1.5.1 doesn't exist