### PR TITLE
fix: replace FileInfo.LinkTarget with libc realpath() for .NET Standard 2.1 compat

### DIFF
--- a/Editor/PlatformPathUtility.cs
+++ b/Editor/PlatformPathUtility.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using System.Runtime.InteropServices;
+
 namespace Hackerzhuli.Code.Editor
 {
     /// <summary>
@@ -5,6 +8,10 @@ namespace Hackerzhuli.Code.Editor
     /// </summary>
     internal static class PlatformPathUtility
     {
+#if UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX
+        [DllImport("libc", EntryPoint = "realpath", CharSet = CharSet.Ansi)]
+        static extern System.IntPtr unix_realpath(string path, System.IntPtr resolved);
+#endif
         /// <summary>
         ///     Gets the real path by resolving symbolic links or shortcuts.
         /// </summary>
@@ -18,13 +25,17 @@ namespace Hackerzhuli.Code.Editor
 #if UNITY_EDITOR_WIN
             return path;
 #elif UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX
-            // On Unix-like systems, resolve symbolic links
+            // On Unix-like systems, resolve symbolic links via libc realpath().
+            // FileInfo.LinkTarget is .NET 6+ only; Unity uses .NET Standard 2.1.
             try
             {
-                var fileInfo = new FileInfo(path);
-                if (fileInfo.Exists && fileInfo.LinkTarget != null)
+                var ptr = unix_realpath(path, System.IntPtr.Zero);
+                if (ptr != System.IntPtr.Zero)
                 {
-                    return fileInfo.LinkTarget;
+                    var resolved = Marshal.PtrToStringAnsi(ptr);
+                    Marshal.FreeHGlobal(ptr);
+                    if (!string.IsNullOrEmpty(resolved))
+                        return resolved;
                 }
             }
             catch


### PR DESCRIPTION
## Problem

`PlatformPathUtility.GetRealPath()` uses `FileInfo.LinkTarget`, which is a **.NET 6+ API**. Unity targets **.NET Standard 2.1**, so this causes a compile error:

```
error CS1061: 'FileInfo' does not contain a definition for 'LinkTarget'
```

This affects **Unity 6000.x** (and likely all Unity versions using .NET Standard 2.1 or .NET Framework 4.x) on macOS and Linux.

## Fix

Replace the `FileInfo.LinkTarget` call with a P/Invoke to libc's `realpath()`, which:

- Is available on all Unix-like platforms (macOS, Linux)
- Works correctly under Unity's .NET Standard 2.1 target
- Provides identical symlink resolution behavior
- Properly frees the allocated buffer

## Changes

- `Editor/PlatformPathUtility.cs`: 1 file changed, 15 insertions, 4 deletions

## Testing

Verified in Unity 6000.2.8f1 on macOS — compiles and resolves symlinks correctly.
